### PR TITLE
Deprecate `MOCK` in favor of `SKIP`

### DIFF
--- a/src/pytest_sphinx.py
+++ b/src/pytest_sphinx.py
@@ -398,10 +398,6 @@ class SphinxDocTestRunner(doctest.DebugRunner):
                     else:
                         self.optionflags &= ~optionflag
 
-            # If 'SKIP' is set, then skip this example.
-            if self.optionflags & doctest.SKIP:
-                continue
-
             # Record that we started this example.
             tries += 1
             if not quiet:
@@ -436,7 +432,18 @@ class SphinxDocTestRunner(doctest.DebugRunner):
             # If the example executed without raising any exceptions,
             # verify its output.
             if exception is None:
-                if check(example.want, got, self.optionflags):
+                # If 'SKIP' is set, run the example code but don't check the
+                # output. This is different than upstream `pytest-sphinx`, which skips
+                # the example entirely.
+                if self.optionflags & doctest.SKIP:
+                    outcome = SUCCESS
+
+                # 'MOCK' is deprecated in favor of 'SKIP'. Here for backwards
+                # compatibility.
+                elif self.optionflags & _MOCK:
+                    outcome = SUCCESS
+
+                elif check(example.want, got, self.optionflags):
                     outcome = SUCCESS
 
             # The example raised an exception:  check if it was expected.


### PR DESCRIPTION
**Problem**

`sphinx.ext.doctest` renders `testcode` and `doctest` blocks in our documentation.  While rendering documentation, the extension complains about our custom `MOCK` option:

```
/ray/doc/source/data/iterating-over-data.rst:72: WARNING: 'MOCK' is not a valid option.
```

This wasn't caught before because warnings were accidentally disabled by https://github.com/ray-project/ray/pull/32741.

**Solution**

Make `SKIP` behave like `MOCK`.

`SKIP` is a valid option. It tells Sphinx to completely skip an example. To avoid warnings, this PR changes the behavior of `SKIP` so that it runs example code but skips the output.

This won't cause any problems:
1. We don't use `SKIP` anywhere, so this wouldn't break anything. `
2. `SKIP` is functionally equivalent to `skipif: True`, so we can still completely skip examples if we want to.