### PR TITLE
Don't check output if no `testoutput`

### DIFF
--- a/src/pytest_sphinx.py
+++ b/src/pytest_sphinx.py
@@ -473,6 +473,12 @@ class SphinxDocTestRunner(doctest.DebugRunner):
                 if self.optionflags & doctest.SKIP:
                     outcome = SUCCESS
 
+                # If you don't add `testoutput`, then don't check the output. This is
+                # different than upstream `pytest-sphinx`, which checks that your code
+                # doesn't produce any output.
+                elif not example.want:
+                    outcome = SUCCESS
+
                 # 'MOCK' is deprecated in favor of 'SKIP'. Here for backwards
                 # compatibility.
                 elif self.optionflags & _MOCK:


### PR DESCRIPTION
Currently, if you don't have a `testoutput` and your `testcode` produces output, `pytest-sphinx` errors and complains that it expected no output. To workaround this, you would add a `testoutput` that matches any output:

```rst
.. testcode::

    # Code that produces long or irrelevant output.

.. testoutput::

    ...
```

To simplify things, this makes `pytest-sphinx` ignore outputs if no `testoutput` is provided:

```rst
.. testcode::
    
    # Code that produces long or irrelevant output.

.. No testoutput boilerplate needed!
```